### PR TITLE
[#43] 즉시 알림 활성화 필드 및 테스트 추가

### DIFF
--- a/src/main/java/ksh/backendserver/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/backendserver/common/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     JOB_FIELD_NOT_FOUND(404, "jobfield.not.found"),
     COMPANY_NOT_FOUND(404, "company.not.found"),
     IMAGE_NOT_FOUND(404, "image.not.found"),
+    INSTANT_NOTIFICATION_NOT_ALLOWED(400, "instant.notification.not.allowed"),
     INTERNAL_SERVER_ERROR(500, "internal.server.error");
 
     private final int status;

--- a/src/main/java/ksh/backendserver/notification/entity/NotificationPreference.java
+++ b/src/main/java/ksh/backendserver/notification/entity/NotificationPreference.java
@@ -30,5 +30,8 @@ public class NotificationPreference extends BaseEntity {
     private NotificationType notificationType;
 
     @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean enableInstant;
+
+    @Column(nullable = false, columnDefinition = "boolean default false")
     private boolean isDeleted;
 }

--- a/src/main/java/ksh/backendserver/notification/facade/NotificationFacade.java
+++ b/src/main/java/ksh/backendserver/notification/facade/NotificationFacade.java
@@ -46,6 +46,6 @@ public class NotificationFacade {
             return;
         }
 
-        notificationService.sendNotifications(subscriptionMatches);
+        notificationService.sendNotifications(subscriptionMatches, true);
     }
 }

--- a/src/main/java/ksh/backendserver/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/ksh/backendserver/post/repository/PostQueryRepositoryImpl.java
@@ -147,6 +147,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
             postTitleContains(dto),
             postedAtInYearMonth(dto),
             postedAtLessOrEqualThanNow(now),
+            closeAtGreaterThanNow(now),
             jobFieldNameEquals(dto),
             notDeleted()
         );
@@ -202,6 +203,10 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
     private BooleanExpression postedAtLessOrEqualThanNow(LocalDateTime now) {
         var actualPostedAt = post.postedAt.coalesce(post.crawledAt);
         return actualPostedAt.loe(now);
+    }
+
+    private BooleanExpression closeAtGreaterThanNow(LocalDateTime now) {
+        return post.closeAt.gt(now);
     }
 
     private BooleanExpression jobFieldNameEquals(PostRequestDto dto) {

--- a/src/main/java/ksh/backendserver/subscription/dto/request/SubscriptionCreationRequestDto.java
+++ b/src/main/java/ksh/backendserver/subscription/dto/request/SubscriptionCreationRequestDto.java
@@ -25,4 +25,7 @@ public class SubscriptionCreationRequestDto {
     @NotEmpty(message = "알림 수단을 최소 1개 이상 선택해야 합니다.")
     @Schema(description = "알림 수단 목록 (EMAIL, SLACK)", example = "[\"EMAIL\", \"SLACK\"]")
     private List<NotificationType> notificationTypes;
+
+    @Schema(description = "즉시 알림 활성화 여부 (SLACK만 지원)", example = "false")
+    private boolean enableInstant;
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -5,4 +5,5 @@ post.not.found=존재하지 않는 공고입니다.
 jobfield.not.found=존재하지 않는 직군입니다.
 company.not.found=존재하지 않는 회사입니다.
 image.not.found=요청한 이미지를 찾을 수 없습니다: {0}
+instant.notification.not.allowed=즉시 알림은 SLACK에서만 지원됩니다.
 internal.server.error=서버 내부 오류가 발생했습니다.

--- a/src/test/java/ksh/backendserver/BackendServerApplicationTests.java
+++ b/src/test/java/ksh/backendserver/BackendServerApplicationTests.java
@@ -2,8 +2,10 @@ package ksh.backendserver;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BackendServerApplicationTests {
 
     @Test

--- a/src/test/java/ksh/backendserver/notification/facade/NotificationFacadeTest.java
+++ b/src/test/java/ksh/backendserver/notification/facade/NotificationFacadeTest.java
@@ -22,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -59,7 +60,7 @@ class NotificationFacadeTest {
         notificationFacade.notifyNewPost(postId);
 
         // then
-        verify(notificationService).sendNotifications(matches);
+        verify(notificationService).sendNotifications(matches, true);
     }
 
     @Test
@@ -77,7 +78,7 @@ class NotificationFacadeTest {
         notificationFacade.notifyNewPost(postId);
 
         // then
-        verify(notificationService, never()).sendNotifications(any());
+        verify(notificationService, never()).sendNotifications(any(), anyBoolean());
     }
 
     private MatchablePost createMatchablePost(Long postId) {

--- a/src/test/java/ksh/backendserver/skill/repository/PostSkillRepositoryTest.java
+++ b/src/test/java/ksh/backendserver/skill/repository/PostSkillRepositoryTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -24,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class PostSkillRepositoryTest {
 
     @Autowired

--- a/src/test/java/ksh/backendserver/subscription/service/SubscriptionServiceTest.java
+++ b/src/test/java/ksh/backendserver/subscription/service/SubscriptionServiceTest.java
@@ -1,0 +1,135 @@
+package ksh.backendserver.subscription.service;
+
+import ksh.backendserver.common.exception.CustomException;
+import ksh.backendserver.common.exception.ErrorCode;
+import ksh.backendserver.company.repository.SubscriptionCompanyRepository;
+import ksh.backendserver.jobfield.repository.SubscriptionJobFieldRepository;
+import ksh.backendserver.notification.enums.NotificationType;
+import ksh.backendserver.notification.repository.NotificationPreferenceRepository;
+import ksh.backendserver.skill.repository.SubscriptionSkillRepository;
+import ksh.backendserver.subscription.dto.request.SubscriptionCreationRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionServiceTest {
+
+    @Mock
+    private SubscriptionSkillRepository subscriptionSkillRepository;
+
+    @Mock
+    private SubscriptionJobFieldRepository subscriptionJobFieldRepository;
+
+    @Mock
+    private SubscriptionCompanyRepository subscriptionCompanyRepository;
+
+    @Mock
+    private NotificationPreferenceRepository notificationPreferenceRepository;
+
+    private SubscriptionService subscriptionService;
+
+    @BeforeEach
+    void setUp() {
+        subscriptionService = new SubscriptionService(
+            subscriptionSkillRepository,
+            subscriptionJobFieldRepository,
+            subscriptionCompanyRepository,
+            notificationPreferenceRepository
+        );
+    }
+
+    @Test
+    @DisplayName("즉시 알림 활성화 시 SLACK이 포함되어 있으면 검증을 통과한다")
+    void validateInstantNotification_withSlack_success() {
+        // Given
+        var request = new SubscriptionCreationRequestDto(
+            List.of(1L),
+            List.of(1L),
+            List.of(1L),
+            List.of(NotificationType.SLACK),
+            true
+        );
+
+        // When & Then
+        assertThatCode(() -> subscriptionService.save(request, 1L))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("즉시 알림 활성화 시 SLACK이 없으면 예외가 발생한다")
+    void validateInstantNotification_withoutSlack_throwsException() {
+        // Given
+        var request = new SubscriptionCreationRequestDto(
+            List.of(1L),
+            List.of(1L),
+            List.of(1L),
+            List.of(NotificationType.EMAIL),
+            true
+        );
+
+        // When & Then
+        assertThatThrownBy(() -> subscriptionService.save(request, 1L))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INSTANT_NOTIFICATION_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("즉시 알림 비활성화 시 SLACK이 없어도 검증을 통과한다")
+    void validateInstantNotification_disabledWithoutSlack_success() {
+        // Given
+        var request = new SubscriptionCreationRequestDto(
+            List.of(1L),
+            List.of(1L),
+            List.of(1L),
+            List.of(NotificationType.EMAIL),
+            false
+        );
+
+        // When & Then
+        assertThatCode(() -> subscriptionService.save(request, 1L))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("즉시 알림 비활성화 시 SLACK이 있어도 검증을 통과한다")
+    void validateInstantNotification_disabledWithSlack_success() {
+        // Given
+        var request = new SubscriptionCreationRequestDto(
+            List.of(1L),
+            List.of(1L),
+            List.of(1L),
+            List.of(NotificationType.EMAIL, NotificationType.SLACK),
+            false
+        );
+
+        // When & Then
+        assertThatCode(() -> subscriptionService.save(request, 1L))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("즉시 알림 활성화 시 EMAIL과 SLACK 모두 포함되어 있으면 검증을 통과한다")
+    void validateInstantNotification_withEmailAndSlack_success() {
+        // Given
+        var request = new SubscriptionCreationRequestDto(
+            List.of(1L),
+            List.of(1L),
+            List.of(1L),
+            List.of(NotificationType.EMAIL, NotificationType.SLACK),
+            true
+        );
+
+        // When & Then
+        assertThatCode(() -> subscriptionService.save(request, 1L))
+            .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Summary

* SubscriptionCreationRequestDto에 enableInstant 필드 추가
* NotificationPreference 엔티티에 enableInstant 필드 추가
* 즉시 알림 검증 로직 테스트 추가 (SubscriptionServiceTest)
* 즉시 알림 필터링 로직 테스트 추가 (NotificationServiceTest)

## Test Plan

- [x] SubscriptionServiceTest - validateInstantNotification 검증 테스트 5개
- [x] NotificationServiceTest - 즉시 알림 필터링 테스트 3개
- [x] 모든 테스트 통과 확인

Closes #43